### PR TITLE
Change require to require_relative

### DIFF
--- a/bin/now-playing
+++ b/bin/now-playing
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'now_playing'
+require_relative '../lib/now_playing'
 
 NowPlaying::CLI.new.call

--- a/lib/now_playing.rb
+++ b/lib/now_playing.rb
@@ -2,9 +2,9 @@ require 'open-uri'
 require 'pry'
 require 'nokogiri'
 
-require "now_playing/version"
-require "now_playing/cli"
-require "now_playing/movie"
+require_relative "now_playing/version"
+require_relative "now_playing/cli"
+require_relative "now_playing/movie"
 
 module NowPlaying
 end


### PR DESCRIPTION
@PeterBell @mendelB 

We have this as part of the rubric, but the first example we show does not use require relative. Change local files to use `require_relative`.
