### PR TITLE
Update Nokogiri search selectors to account for changes to IMDB page structure

### DIFF
--- a/lib/now_playing/movie.rb
+++ b/lib/now_playing/movie.rb
@@ -22,7 +22,7 @@ class NowPlaying::Movie
   end
 
   def summary
-    @summary ||= plot_summary_doc.search("p.plotSummary").text.strip
+    @summary ||= plot_summary_doc.search("#plot-summaries-content p").text.strip
   end
 
   def stars

--- a/lib/now_playing/movie.rb
+++ b/lib/now_playing/movie.rb
@@ -26,7 +26,7 @@ class NowPlaying::Movie
   end
 
   def stars
-    @stars ||= doc.search("div[itemprop='actors'] span[itemprop='name']").collect{|e| e.text.strip}.join(", ")
+    @stars ||= doc.search("#titleCast span[itemprop='name']").collect{|e| e.text.strip}.join(", ")
   end
 
   private


### PR DESCRIPTION
Plot summary and cast scraping off the IMDB movie details pages had stopped working, so I updated the Nokogiri search selectors to once again correctly retrieve this data.